### PR TITLE
fix: transposed the event labels before using them to identify event-related timing in the sortEvents() function

### DIFF
--- a/kinarmzip2mat.m
+++ b/kinarmzip2mat.m
@@ -231,7 +231,16 @@ end
 function [events, event_names] = sortEvents(data)
 
 samplerate = data.ANALOG.RATE;
-occured_events = cellfun(@(x) deblank(x'), data.EVENTS.LABELS ,'uniformoutput',false)';% Remove whitespaces
+
+% check the dimensions of the labels - need to transpose the labels if they
+% are column arrays
+[row, col] = size(data(1).EVENTS.LABELS{1});
+if row > 1 & col == 1
+        occured_events = cellfun(@(x) deblank(x'), data.EVENTS.LABELS ,'uniformoutput',false)';% Remove whitespaces
+else
+        occured_events = cellfun(@(x) deblank(x), data.EVENTS.LABELS ,'uniformoutput',false)';% Remove whitespaces
+end
+
 event_names = data.EVENT_DEFINITIONS.LABELS';% Get all the possible events
 n_event = length(event_names);
 events = nan(n_event,3);

--- a/kinarmzip2mat.m
+++ b/kinarmzip2mat.m
@@ -231,7 +231,7 @@ end
 function [events, event_names] = sortEvents(data)
 
 samplerate = data.ANALOG.RATE;
-occured_events = cellfun(@(x) deblank(x), data.EVENTS.LABELS ,'uniformoutput',false)';% Remove whitespaces
+occured_events = cellfun(@(x) deblank(x'), data.EVENTS.LABELS ,'uniformoutput',false)';% Remove whitespaces
 event_names = data.EVENT_DEFINITIONS.LABELS';% Get all the possible events
 n_event = length(event_names);
 events = nan(n_event,3);


### PR DESCRIPTION
The event labels from Kinarm's c3d file contains column char arrays 
```
>> data(1).EVENTS.LABELS{1}

ans =

  14×1 char array

    'W'
    'A'
    'I'
    'T'
    '_'
    'F'
    'O'
    'R'
    '_'
    'S'
    'T'
    'A'
    'R'
    'T'
```

Without transposing the char arrays, the resulting occurred_events cell would contain arrays of strings (note the square brackets):

```
    {["STAY_CENTRE"      ]}
    {["TARGET_ON"        ]}
    {["EXIT_START_TARGET"]}
    {["HOLD_AT_TARGET"   ]}
    {["END_OF_REACH"     ]}
    {["STAY_CENTRE"      ]}
    {["TARGET_ON"        ]}
    {["EXIT_START_TARGET"]}
    {["HOLD_AT_TARGET"   ]}
    {["END_OF_REACH"     ]}
```

This would in turn prevent the subsequent identification of the events and storing of the event-related values (e.g., various timestamps) here:

```
event_order = find(strcmpi(event_names(m),occured_events)); % order of occurence
```

I am not sure whether this is an oversight, or whether different Kinarm output contains different formats for the event labels. If it is the latter, maybe an if statement can be used instead:

```
[row, col] = size(data(1).EVENTS.LABELS{1});
if row > 1 & col == 1
        occured_events = cellfun(@(x) deblank(x'), data.EVENTS.LABELS ,'uniformoutput',false)';% Remove whitespaces
else
        occured_events = cellfun(@(x) deblank(x), data.EVENTS.LABELS ,'uniformoutput',false)';% Remove whitespaces
end
```
